### PR TITLE
[HIPPEROS] Support for aarch64, i686 and powerpc64

### DIFF
--- a/bfd/config.bfd
+++ b/bfd/config.bfd
@@ -244,7 +244,7 @@ case "${targ}" in
     targ_archs="$targ_archs bfd_i386_arch bfd_powerpc_arch bfd_rs6000_arch"
     want64=true
     ;;
-  aarch64-*-elf | aarch64-*-rtems*)
+  aarch64-*-elf | aarch64-*-rtems* | aarch64-*-hipperos*)
     targ_defvec=aarch64_elf64_le_vec
     targ_selvecs="aarch64_elf64_be_vec aarch64_elf32_le_vec aarch64_elf32_be_vec arm_elf32_le_vec arm_elf32_be_vec"
     want64=true
@@ -636,7 +636,8 @@ case "${targ}" in
     ;;
   i[3-7]86-*-sysv4* | i[3-7]86-*-unixware* | \
   i[3-7]86-*-elf* | i[3-7]86-*-sco3.2v5* | \
-  i[3-7]86-*-dgux* | i[3-7]86-*-sysv5* | i[3-7]86-*-rtems*)
+  i[3-7]86-*-dgux* | i[3-7]86-*-sysv5* | i[3-7]86-*-rtems* | \
+  i[3-7]86-*-hipperos*)
     targ_defvec=i386_elf32_vec
     targ_selvecs="iamcu_elf32_vec i386_coff_vec"
     ;;
@@ -1377,7 +1378,7 @@ case "${targ}" in
     want64=true
     ;;
   powerpc64-*-elf* | powerpc-*-elf64* | powerpc64-*-linux* | \
-  powerpc64-*-*bsd*)
+  powerpc64-*-*bsd* | powerpc64-*-hipperos*)
     targ_defvec=powerpc_elf64_vec
     targ_selvecs="powerpc_elf64_le_vec powerpc_elf32_vec powerpc_elf32_le_vec rs6000_xcoff_vec rs6000_xcoff64_vec rs6000_xcoff64_aix_vec"
     want64=true

--- a/gas/configure.tgt
+++ b/gas/configure.tgt
@@ -126,6 +126,7 @@ generic_target=${cpu_type}-$vendor-$os
 case ${generic_target} in
   aarch64*-*-elf*)			fmt=elf;;
   aarch64*-*-fuchsia*)			fmt=elf;;
+  aarch64*-*-hipperos*)			fmt=elf;;
   aarch64*-*-linux*)			fmt=elf em=linux
     case ${cpu}-${os} in
       aarch64*-linux-gnu_ilp32)		arch=aarch64:32 ;;
@@ -228,6 +229,7 @@ case ${generic_target} in
   i386-*-elfiamcu)			fmt=elf arch=iamcu ;;
   i386-*-elf*)				fmt=elf ;;
   i386-*-fuchsia*)			fmt=elf ;;
+  i386-*-hipperos*)			fmt=elf ;;
   i386-*-kaos*)				fmt=elf ;;
   i386-*-bsd*)				fmt=aout em=386bsd ;;
   i386-*-nacl*)				fmt=elf em=nacl
@@ -393,6 +395,7 @@ case ${generic_target} in
   ppc-*-beos*)				fmt=coff ;;
   ppc-*-*n*bsd* | ppc-*-elf*)		fmt=elf ;;
   ppc-*-eabi* | ppc-*-sysv4*)		fmt=elf ;;
+  ppc-*-hipperos*)		    fmt=elf ;;
   ppc-*-linux-*)			fmt=elf em=linux ;;
   ppc-*-solaris*)			fmt=elf em=solaris ;;
   ppc-*-macos*)				fmt=coff em=macos ;;

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -56,6 +56,8 @@ aarch64-*-freebsd*)	targ_emul=aarch64fbsd
 			targ_extra_emuls="aarch64fbsdb aarch64elf" ;;
 aarch64-*-fuchsia*)	targ_emul=aarch64elf
 			targ_extra_emuls="aarch64elfb armelf armelfb" ;;
+aarch64-*-hipperos*)	targ_emul=aarch64elf
+			targ_extra_emuls="aarch64elfb armelf armelfb" ;;
 aarch64_be-*-linux-gnu_ilp32)
 			targ_emul=aarch64linux32b
 			targ_extra_libpath="aarch64linuxb aarch64linux aarch64linux32 armelfb_linux_eabi armelf_linux_eabi"
@@ -332,7 +334,7 @@ x86_64-*-netbsd*)	targ_emul=elf_x86_64
 i[3-7]86-*-netware)	targ_emul=i386nw ;;
 i[3-7]86-*-elfiamcu)	targ_emul=elf_iamcu
 			targ_extra_emuls=elf_i386 ;;
-i[3-7]86-*-elf* | i[3-7]86-*-rtems*)
+i[3-7]86-*-elf* | i[3-7]86-*-rtems* | i[3-7]86-*-hipperos*)
 			targ_emul=elf_i386
 			targ_extra_emuls=elf_iamcu ;;
 x86_64-*-elf* | x86_64-*-rtems* | x86_64-*-fuchsia*)
@@ -618,7 +620,8 @@ powerpc-*-vxworks*)
 powerpc*-*-elf* | powerpc*-*-eabi* | powerpc*-*-sysv* \
   | powerpc*-*-linux* | powerpc*-*-netbsd* | powerpc*-*-openbsd* \
   | powerpc*-*-rtems* \
-  | powerpc*-*-solaris* | powerpc*-*-kaos* | powerpc*-*-vxworks*)
+  | powerpc*-*-solaris* | powerpc*-*-kaos* | powerpc*-*-vxworks* \
+  | powerpc*-*-hipperos)
 			case "${targ}" in
 			powerpc64*)
 			    targ_emul=elf64ppc


### PR DESCRIPTION
Add support for all the architectures supported by the HIPPEROS RTOS.

Added support for:
- aarch64-hipperos
- i686-hipperos
- powerpc64-hipperos