### PR TITLE
[HIPPEROS] Adds support for linker scripts

### DIFF
--- a/ld/Makefile.am
+++ b/ld/Makefile.am
@@ -394,6 +394,8 @@ ALL_64_EMULATION_SOURCES = \
 	eaarch64cloudabib.c \
 	eaarch64fbsd.c \
 	eaarch64fbsdb.c \
+	eaarch64hipperos.c \
+	eaarch64hipperosb.c \
 	eaarch64linux.c \
 	eaarch64linuxb.c \
 	eaarch64linux32.c \
@@ -1541,6 +1543,19 @@ eaarch64fbsdb.c: $(srcdir)/emulparams/aarch64fbsdb.sh $(srcdir)/emulparams/aarch
   $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
+eaarch64hipperos.c: $(srcdir)/emulparams/aarch64hipperos.sh \
+  $(srcdir)/emulparams/aarch64elf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+eaarch64hipperosb.c: $(srcdir)/emulparams/aarch64hipperosb.sh \
+  $(srcdir)/emulparams/aarch64hipperos.sh \
+  $(srcdir)/emulparams/aarch64elf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
 eaarch64linux.c: $(srcdir)/emulparams/aarch64linux.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
@@ -1551,10 +1566,12 @@ eaarch64linuxb.c: $(srcdir)/emulparams/aarch64linuxb.sh $(srcdir)/emulparams/aar
 
 eaarch64linux32.c: $(srcdir)/emulparams/aarch64linux32.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
 eaarch64linux32b.c: $(srcdir)/emulparams/aarch64linux32b.sh $(srcdir)/emulparams/aarch64linux32.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
 epc532macha.c: $(srcdir)/emulparams/pc532macha.sh \

--- a/ld/Makefile.am
+++ b/ld/Makefile.am
@@ -262,6 +262,7 @@ ALL_EMULATION_SOURCES = \
 	eelf32or1k_linux.c \
 	eelf32ppc.c \
 	eelf32ppc_fbsd.c \
+	eelf32ppc_hipperos.c \
 	eelf32ppclinux.c \
 	eelf32ppcnto.c \
 	eelf32ppcsim.c \
@@ -448,6 +449,7 @@ ALL_64_EMULATION_SOURCES = \
 	eelf64mmix.c \
 	eelf64ppc.c \
 	eelf64ppc_fbsd.c \
+	eelf64ppc_hipperos.c \
 	eelf64rdos.c \
 	eelf64tilegx.c \
 	eelf64tilegx_be.c \
@@ -1218,6 +1220,13 @@ eelf32ppc_fbsd.c: $(srcdir)/emulparams/elf32ppc_fbsd.sh \
   $(srcdir)/emultempl/ppc32elf.em ldemul-list.h \
   $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
+eelf32ppc_hipperos.c: $(srcdir)/emulparams/elf32ppc_hipperos.sh \
+  $(srcdir)/emulparams/elf32ppc.sh $(srcdir)/emulparams/elf32ppccommon.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
+  $(srcdir)/emulparams/dynamic_undefined_weak.sh \
+  $(srcdir)/emultempl/ppc32elf.em ldemul-list.h \
+  $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
 eelf32ppclinux.c: $(srcdir)/emulparams/elf32ppclinux.sh \
   $(srcdir)/emulparams/elf32ppc.sh $(srcdir)/emulparams/elf32ppccommon.sh \
   $(srcdir)/emulparams/dynamic_undefined_weak.sh \
@@ -1833,6 +1842,13 @@ eelf64ppc.c: $(srcdir)/emulparams/elf64ppc.sh \
   $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
 eelf64ppc_fbsd.c: $(srcdir)/emulparams/elf64ppc_fbsd.sh \
+  $(srcdir)/emulparams/dynamic_undefined_weak.sh \
+  $(srcdir)/emultempl/ppc64elf.em ldemul-list.h \
+  $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+eelf64ppc_hipperos.c: $(srcdir)/emulparams/elf64ppc_hipperos.sh \
+  $(srcdir)/emulparams/elf64ppc.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(srcdir)/emulparams/dynamic_undefined_weak.sh \
   $(srcdir)/emultempl/ppc64elf.em ldemul-list.h \
   $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}

--- a/ld/Makefile.am
+++ b/ld/Makefile.am
@@ -170,6 +170,7 @@ ALL_EMULATION_SOURCES = \
 	earmelf.c \
 	earmelf_fbsd.c \
 	earmelf_fuchsia.c \
+	earmelf_hipperos.c \
 	earmelf_linux.c \
 	earmelf_linux_eabi.c \
 	earmelf_linux_fdpiceabi.c \
@@ -180,6 +181,7 @@ ALL_EMULATION_SOURCES = \
 	earmelfb.c \
 	earmelfb_fbsd.c \
 	earmelfb_fuchsia.c \
+	earmelfb_hipperos.c \
 	earmelfb_linux.c \
 	earmelfb_linux_eabi.c \
 	earmelfb_linux_fdpiceabi.c \
@@ -701,6 +703,12 @@ earmelf_fuchsia.c: $(srcdir)/emulparams/armelf_fuchsia.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
+earmelf_hipperos.c: $(srcdir)/emulparams/armelf_hipperos.sh \
+  $(srcdir)/emulparams/armelf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
 earmelf_linux.c: $(srcdir)/emulparams/armelf_linux.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
@@ -749,6 +757,13 @@ earmelfb_fbsd.c: $(srcdir)/emulparams/armelfb_fbsd.sh \
 
 earmelfb_fuchsia.c: $(srcdir)/emulparams/armelfb_fuchsia.sh \
   $(srcdir)/emulparams/armelf_fuchsia.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+earmelfb_hipperos.c: $(srcdir)/emulparams/armelfb_hipperos.sh \
+  $(srcdir)/emulparams/armelf_hipperos.sh \
+  $(srcdir)/emulparams/armelf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 

--- a/ld/Makefile.am
+++ b/ld/Makefile.am
@@ -287,6 +287,7 @@ ALL_EMULATION_SOURCES = \
 	eelf_i386_be.c \
 	eelf_i386_chaos.c \
 	eelf_i386_fbsd.c \
+	eelf_i386_hipperos.c \
 	eelf_i386_ldso.c \
 	eelf_i386_nacl.c \
 	eelf_i386_sol2.c \
@@ -1311,6 +1312,11 @@ eelf_i386_chaos.c: $(srcdir)/emulparams/elf_i386_chaos.sh \
 
 eelf_i386_fbsd.c: $(srcdir)/emulparams/elf_i386_fbsd.sh \
   $(srcdir)/emulparams/elf_i386.sh \
+  $(ELF_X86_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+eelf_i386_hipperos.c: $(srcdir)/emulparams/elf_i386_hipperos.sh \
+  $(srcdir)/emulparams/elf_i386.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(ELF_X86_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
 eelf_i386_ldso.c: $(srcdir)/emulparams/elf_i386_ldso.sh \

--- a/ld/Makefile.in
+++ b/ld/Makefile.in
@@ -774,6 +774,7 @@ ALL_EMULATION_SOURCES = \
 	eelf_i386_be.c \
 	eelf_i386_chaos.c \
 	eelf_i386_fbsd.c \
+	eelf_i386_hipperos.c \
 	eelf_i386_ldso.c \
 	eelf_i386_nacl.c \
 	eelf_i386_sol2.c \
@@ -1394,6 +1395,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf_i386_be.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf_i386_chaos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf_i386_fbsd.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf_i386_hipperos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf_i386_ldso.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf_i386_nacl.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf_i386_sol2.Po@am__quote@
@@ -2919,6 +2921,11 @@ eelf_i386_chaos.c: $(srcdir)/emulparams/elf_i386_chaos.sh \
 
 eelf_i386_fbsd.c: $(srcdir)/emulparams/elf_i386_fbsd.sh \
   $(srcdir)/emulparams/elf_i386.sh \
+  $(ELF_X86_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+eelf_i386_hipperos.c: $(srcdir)/emulparams/elf_i386_hipperos.sh \
+  $(srcdir)/emulparams/elf_i386.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(ELF_X86_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
 eelf_i386_ldso.c: $(srcdir)/emulparams/elf_i386_ldso.sh \

--- a/ld/Makefile.in
+++ b/ld/Makefile.in
@@ -521,6 +521,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -656,6 +657,7 @@ ALL_EMULATION_SOURCES = \
 	earmelf.c \
 	earmelf_fbsd.c \
 	earmelf_fuchsia.c \
+	earmelf_hipperos.c \
 	earmelf_linux.c \
 	earmelf_linux_eabi.c \
 	earmelf_linux_fdpiceabi.c \
@@ -666,6 +668,7 @@ ALL_EMULATION_SOURCES = \
 	earmelfb.c \
 	earmelfb_fbsd.c \
 	earmelfb_fuchsia.c \
+	earmelfb_hipperos.c \
 	earmelfb_linux.c \
 	earmelfb_linux_eabi.c \
 	earmelfb_linux_fdpiceabi.c \
@@ -1217,6 +1220,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelf.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelf_fbsd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelf_fuchsia.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelf_hipperos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelf_linux.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelf_linux_eabi.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelf_linux_fdpiceabi.Po@am__quote@
@@ -1227,6 +1231,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelfb.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelfb_fbsd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelfb_fuchsia.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelfb_hipperos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelfb_linux.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelfb_linux_eabi.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earmelfb_linux_fdpiceabi.Po@am__quote@
@@ -2302,6 +2307,12 @@ earmelf_fuchsia.c: $(srcdir)/emulparams/armelf_fuchsia.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
+earmelf_hipperos.c: $(srcdir)/emulparams/armelf_hipperos.sh \
+  $(srcdir)/emulparams/armelf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
 earmelf_linux.c: $(srcdir)/emulparams/armelf_linux.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
@@ -2350,6 +2361,13 @@ earmelfb_fbsd.c: $(srcdir)/emulparams/armelfb_fbsd.sh \
 
 earmelfb_fuchsia.c: $(srcdir)/emulparams/armelfb_fuchsia.sh \
   $(srcdir)/emulparams/armelf_fuchsia.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+earmelfb_hipperos.c: $(srcdir)/emulparams/armelfb_hipperos.sh \
+  $(srcdir)/emulparams/armelf_hipperos.sh \
+  $(srcdir)/emulparams/armelf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/armelf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 

--- a/ld/Makefile.in
+++ b/ld/Makefile.in
@@ -749,6 +749,7 @@ ALL_EMULATION_SOURCES = \
 	eelf32or1k_linux.c \
 	eelf32ppc.c \
 	eelf32ppc_fbsd.c \
+	eelf32ppc_hipperos.c \
 	eelf32ppclinux.c \
 	eelf32ppcnto.c \
 	eelf32ppcsim.c \
@@ -934,6 +935,7 @@ ALL_64_EMULATION_SOURCES = \
 	eelf64mmix.c \
 	eelf64ppc.c \
 	eelf64ppc_fbsd.c \
+	eelf64ppc_hipperos.c \
 	eelf64rdos.c \
 	eelf64tilegx.c \
 	eelf64tilegx_be.c \
@@ -1342,6 +1344,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32or1k_linux.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32ppc.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32ppc_fbsd.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32ppc_hipperos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32ppclinux.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32ppcnto.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32ppcsim.Po@am__quote@
@@ -1383,6 +1386,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64mmix.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64ppc.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64ppc_fbsd.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64ppc_hipperos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64rdos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64tilegx.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64tilegx_be.Po@am__quote@
@@ -2824,6 +2828,13 @@ eelf32ppc_fbsd.c: $(srcdir)/emulparams/elf32ppc_fbsd.sh \
   $(srcdir)/emultempl/ppc32elf.em ldemul-list.h \
   $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
+eelf32ppc_hipperos.c: $(srcdir)/emulparams/elf32ppc_hipperos.sh \
+  $(srcdir)/emulparams/elf32ppc.sh $(srcdir)/emulparams/elf32ppccommon.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
+  $(srcdir)/emulparams/dynamic_undefined_weak.sh \
+  $(srcdir)/emultempl/ppc32elf.em ldemul-list.h \
+  $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
 eelf32ppclinux.c: $(srcdir)/emulparams/elf32ppclinux.sh \
   $(srcdir)/emulparams/elf32ppc.sh $(srcdir)/emulparams/elf32ppccommon.sh \
   $(srcdir)/emulparams/dynamic_undefined_weak.sh \
@@ -3437,6 +3448,13 @@ eelf64ppc.c: $(srcdir)/emulparams/elf64ppc.sh \
   $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
 eelf64ppc_fbsd.c: $(srcdir)/emulparams/elf64ppc_fbsd.sh \
+  $(srcdir)/emulparams/dynamic_undefined_weak.sh \
+  $(srcdir)/emultempl/ppc64elf.em ldemul-list.h \
+  $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+eelf64ppc_hipperos.c: $(srcdir)/emulparams/elf64ppc_hipperos.sh \
+  $(srcdir)/emulparams/elf64ppc.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(srcdir)/emulparams/dynamic_undefined_weak.sh \
   $(srcdir)/emultempl/ppc64elf.em ldemul-list.h \
   $(ELF_DEPS) $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}

--- a/ld/Makefile.in
+++ b/ld/Makefile.in
@@ -880,6 +880,8 @@ ALL_64_EMULATION_SOURCES = \
 	eaarch64cloudabib.c \
 	eaarch64fbsd.c \
 	eaarch64fbsdb.c \
+	eaarch64hipperos.c \
+	eaarch64hipperosb.c \
 	eaarch64linux.c \
 	eaarch64linuxb.c \
 	eaarch64linux32.c \
@@ -1199,6 +1201,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64elfb.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64fbsd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64fbsdb.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64hipperos.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64hipperosb.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64linux.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64linux32.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaarch64linux32b.Po@am__quote@
@@ -3142,6 +3146,19 @@ eaarch64fbsd.c: $(srcdir)/emulparams/aarch64fbsd.sh \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 
 eaarch64fbsdb.c: $(srcdir)/emulparams/aarch64fbsdb.sh $(srcdir)/emulparams/aarch64fbsd.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+eaarch64hipperos.c: $(srcdir)/emulparams/aarch64hipperos.sh \
+  $(srcdir)/emulparams/aarch64elf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
+  $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
+  $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
+
+eaarch64hipperosb.c: $(srcdir)/emulparams/aarch64hipperosb.sh \
+  $(srcdir)/emulparams/aarch64hipperos.sh \
+  $(srcdir)/emulparams/aarch64elf.sh \
+  $(srcdir)/emulparams/elf_hipperos.sh \
   $(ELF_DEPS) $(srcdir)/emultempl/aarch64elf.em \
   $(srcdir)/scripttempl/elf.sc ${GEN_DEPENDS}
 

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -304,7 +304,7 @@ x86_64-*-netbsd*)	targ_emul=elf_x86_64
 			esac ;;
 i[3-7]86-*-elfiamcu)	targ_emul=elf_iamcu
 			targ_extra_emuls=elf_i386 ;;
-i[3-7]86-*-elf* | i[3-7]86-*-rtems* | i[3-7]86-*-hipperos*)
+i[3-7]86-*-elf* | i[3-7]86-*-rtems*)
 			targ_emul=elf_i386
 			targ_extra_emuls=elf_iamcu ;;
 x86_64-*-elf* | x86_64-*-rtems* | x86_64-*-fuchsia*)
@@ -333,6 +333,9 @@ x86_64-*-freebsd* | x86_64-*-kfreebsd*-gnu)
 			    | sed -e 's/x86_64/i386/'` ;;
 i[3-7]86-*-gnu*)	targ_emul=elf_i386
 			targ_extra_emuls=elf_iamcu ;;
+i[3-7]86-*-hipperos*)
+			targ_emul=elf_i386_hipperos
+			targ_extra_emuls="elf_i386" ;;
 i[3-7]86-*-msdos*)	targ_emul=i386msdos; targ_extra_emuls=i386aout ;;
 i[3-7]86-*-moss*)	targ_emul=i386moss; targ_extra_emuls=i386msdos ;;
 i[3-7]86-*-winnt*)	targ_emul=i386pe ;

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -56,8 +56,7 @@ aarch64-*-freebsd*)	targ_emul=aarch64fbsd
 			targ_extra_emuls="aarch64fbsdb aarch64elf" ;;
 aarch64-*-fuchsia*)	targ_emul=aarch64elf
 			targ_extra_emuls="aarch64elfb armelf armelfb" ;;
-aarch64-*-hipperos*)	targ_emul=aarch64elf
-			targ_extra_emuls="aarch64elfb armelf armelfb" ;;
+aarch64-*-hipperos*)	targ_emul=aarch64hipperos ;;
 aarch64_be-*-linux-gnu_ilp32)
 			targ_emul=aarch64linux32b
 			targ_extra_libpath="aarch64linuxb aarch64linux aarch64linux32 armelfb_linux_eabi armelf_linux_eabi"

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -535,6 +535,11 @@ powerpc-*-freebsd* | powerpc-*-kfreebsd*-gnu)
 			targ_extra_emuls="elf32ppc elf32ppcsim"
 			targ_extra_libpath=elf32ppc;
 			tdir_elf32ppcsim=`echo ${targ_alias} | sed -e 's/ppc/ppcsim/'` ;;
+powerpc-*-hipperos*)
+			targ_emul=elf32ppc_hipperos
+			targ_extra_emuls="elf32ppc elf32ppcsim"
+			targ_extra_libpath=elf32ppc;
+			tdir_elf32ppcsim=`echo ${targ_alias} | sed -e 's/ppc/ppcsim/'` ;;
 powerpc64-*-freebsd*)
 			targ_emul=elf64ppc_fbsd
 			targ_extra_emuls="elf64ppc elf32ppc_fbsd elf32ppc"
@@ -542,14 +547,20 @@ powerpc64-*-freebsd*)
 			tdir_elf32ppc=`echo "${targ_alias}" | sed -e 's/64//'`
 			tdir_elf32ppc_fbsd=$tdir_elf32ppc
 			;;
+powerpc64-*-hipperos*)
+			targ_emul=elf64ppc_hipperos
+			targ_extra_emuls="elf64ppc elf32ppc_hipperos elf32ppc"
+			targ_extra_libpath="elf32ppc"
+			tdir_elf32ppc=`echo "${targ_alias}" | sed -e 's/64//'`
+			tdir_elf32ppc_hipperos=$tdir_elf32ppc
+			;;
 powerpc-*-vxworks*)
 			targ_emul=elf32ppcvxworks
 			targ_extra_emuls="elf32ppc elf32ppclinux elf32ppcsim" ;;
 powerpc*-*-elf* | powerpc*-*-eabi* | powerpc*-*-sysv* \
   | powerpc*-*-linux* | powerpc*-*-netbsd* | powerpc*-*-openbsd* \
   | powerpc*-*-rtems* \
-  | powerpc*-*-solaris* | powerpc*-*-kaos* | powerpc*-*-vxworks* \
-  | powerpc*-*-hipperos)
+  | powerpc*-*-solaris* | powerpc*-*-kaos* | powerpc*-*-vxworks*)
 			case "${targ}" in
 			powerpc64*)
 			    targ_emul=elf64ppc

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -119,7 +119,7 @@ armeb-*-elf | armeb-*-eabi*)
 			targ_emul=armelfb ;;
 arm-*-elf | arm*-*-eabi* | arm-*-rtems*)
 			targ_emul=armelf ;;
-arm-*-hipperos*)	targ_emul=armelf ;;
+arm-*-hipperos*)	targ_emul=armelf_hipperos ;;
 arm*-*-symbianelf*)	targ_emul=armsymbian;;
 arm-*-kaos*)		targ_emul=armelf ;;
 arm9e-*-elf)		targ_emul=armelf ;;

--- a/ld/emulparams/aarch64hipperos.sh
+++ b/ld/emulparams/aarch64hipperos.sh
@@ -1,0 +1,2 @@
+. ${srcdir}/emulparams/aarch64elf.sh
+. ${srcdir}/emulparams/elf_hipperos.sh

--- a/ld/emulparams/aarch64hipperosb.sh
+++ b/ld/emulparams/aarch64hipperosb.sh
@@ -1,0 +1,2 @@
+. ${srcdir}/emulparams/aarch64hipperos.sh
+OUTPUT_FORMAT="elf64-bigaarch64"

--- a/ld/emulparams/armelf_hipperos.sh
+++ b/ld/emulparams/armelf_hipperos.sh
@@ -1,0 +1,2 @@
+. ${srcdir}/emulparams/armelf.sh
+. ${srcdir}/emulparams/elf_hipperos.sh

--- a/ld/emulparams/armelfb_hipperos.sh
+++ b/ld/emulparams/armelfb_hipperos.sh
@@ -1,0 +1,2 @@
+. ${srcdir}/emulparams/armelf_hipperos.sh
+OUTPUT_FORMAT="$BIG_OUTPUT_FORMAT"

--- a/ld/emulparams/elf32ppc_hipperos.sh
+++ b/ld/emulparams/elf32ppc_hipperos.sh
@@ -1,0 +1,2 @@
+. ${srcdir}/emulparams/elf32ppc.sh
+. ${srcdir}/emulparams/elf_hipperos.sh

--- a/ld/emulparams/elf64ppc_hipperos.sh
+++ b/ld/emulparams/elf64ppc_hipperos.sh
@@ -1,0 +1,2 @@
+. ${srcdir}/emulparams/elf64ppc.sh
+. ${srcdir}/emulparams/elf_hipperos.sh

--- a/ld/emulparams/elf_hipperos.sh
+++ b/ld/emulparams/elf_hipperos.sh
@@ -1,5 +1,5 @@
 # If you change this file, please also look at files which source this one:
-# armelf_hipperos.sh armelfb_hipperos.sh
+# aarch64hipperos.sh aarch64hipperosb.sh armelf_hipperos.sh armelfb_hipperos.sh
 
 unset STACK_ADDR
 

--- a/ld/emulparams/elf_hipperos.sh
+++ b/ld/emulparams/elf_hipperos.sh
@@ -1,5 +1,6 @@
 # If you change this file, please also look at files which source this one:
 # aarch64hipperos.sh aarch64hipperosb.sh armelf_hipperos.sh armelfb_hipperos.sh
+# elf32ppc_hipperos.sh elf64ppc_hipperos.sh
 
 unset STACK_ADDR
 

--- a/ld/emulparams/elf_hipperos.sh
+++ b/ld/emulparams/elf_hipperos.sh
@@ -1,6 +1,6 @@
 # If you change this file, please also look at files which source this one:
 # aarch64hipperos.sh aarch64hipperosb.sh armelf_hipperos.sh armelfb_hipperos.sh
-# elf32ppc_hipperos.sh elf64ppc_hipperos.sh
+# elf_i386_hipperos.sh elf32ppc_hipperos.sh elf64ppc_hipperos.sh
 
 unset STACK_ADDR
 

--- a/ld/emulparams/elf_hipperos.sh
+++ b/ld/emulparams/elf_hipperos.sh
@@ -1,0 +1,14 @@
+# If you change this file, please also look at files which source this one:
+# armelf_hipperos.sh armelfb_hipperos.sh
+
+unset STACK_ADDR
+
+# Add a page and then align.
+# This ensures that we have an empty page.
+RODATA_FULL_ADDR=". + ${MAXPAGESIZE};\
+ . = ALIGN (${MAXPAGESIZE})"
+
+DATA_SEGMENT_ALIGN=". + ${MAXPAGESIZE};\
+ . = ALIGN (${MAXPAGESIZE})"
+DATA_SEGMENT_END=""
+DATA_SEGMENT_RELRO_END=""

--- a/ld/emulparams/elf_i386_hipperos.sh
+++ b/ld/emulparams/elf_i386_hipperos.sh
@@ -1,0 +1,2 @@
+. ${srcdir}/emulparams/elf_i386.sh
+. ${srcdir}/emulparams/elf_hipperos.sh

--- a/ld/scripttempl/elf.sc
+++ b/ld/scripttempl/elf.sc
@@ -11,6 +11,7 @@
 #	SMALL_DATA_CTOR - .ctors contains small data.
 #	SMALL_DATA_DTOR - .dtors contains small data.
 #	DATA_ADDR - if end-of-text-plus-one-page isn't right for data start
+#	RODATA_FULL_ADDR - if end-of-text-plus-one-page isn't right for rodata start
 #	INITIAL_READONLY_SECTIONS - at start of text segment
 #	OTHER_READONLY_SECTIONS - other than .text .init .rodata ...
 #		(e.g., .PARISC.milli)
@@ -531,7 +532,9 @@ cat <<EOF
 EOF
 
 if test -n "${SEPARATE_CODE}${SEPARATE_TEXT}"; then
-  if test -n "${RODATA_ADDR}"; then
+  if test -n "${RODATA_FULL_ADDR}"; then
+    RODATA_ADDR="${RODATA_FULL_ADDR}"
+  elif test -n "${RODATA_ADDR}"; then
     RODATA_ADDR="\
 SEGMENT_START(\"rodata-segment\", ${RODATA_ADDR}) + SIZEOF_HEADERS"
   else


### PR DESCRIPTION
Configures the way the linker scripts are generated when targeting
HIPPEROS.
It mostly uses the default behavior, except regarding the `rodata`
section.
We prefer to have a blank page between `text` and `rodata` sections.

Part of the implementation of KERNEL-554.